### PR TITLE
removed petition page link to itself, made titles site primary color

### DIFF
--- a/client/stylesheets/petition.less
+++ b/client/stylesheets/petition.less
@@ -180,7 +180,6 @@
 }
 
 .title {
-  color: @brand-primary;
   font-size: 200%;
   line-height: 30px;
   @media (min-width: @screen-sm-min) {

--- a/client/views/posts/post_page.html
+++ b/client/views/posts/post_page.html
@@ -4,7 +4,7 @@
       <div class="col-xs-12 col-sm-12 col-md-10 col-md-offset-1 col-lg-8 col-lg-offset-2">
         <div class="module module-sm">
           <p class="petition-title-wrapper">
-            <p class="title">{{post.title}}</p>
+            <p><a class="title" href="{{pathFor 'postPage' _id=post._id}}">{{post.title}}</a></p>
             <div class="footer-subtitle">{{post.author}} <br> {{ submitted_at }}</div>
           </p>
           {{#if isInRole 'admin' 'moderator'}}


### PR DESCRIPTION
I don't know if titles on a petition _need_ to link to the page you're already on. But it's nice that they're orange (inherited from the a tag, I think). So this removes the link while keeping them orange.
