### PR TITLE
Added pop animation to squares

### DIFF
--- a/client/stylesheets/petition.less
+++ b/client/stylesheets/petition.less
@@ -160,12 +160,10 @@
     from { opacity: 0; transform: scale(0.5);}
     to   { opacity: 1; transform: scale(1);}
 }
-
 @-webkit-keyframes popin {
     from { opacity: 0; -webkit-transform: scale(0.5);}
     to   { opacity: 1; -webkit-transform: scale(1);}
 }
-
 @-moz-keyframes popin {
     from { opacity: 0; -moz-transform: scale(0.5);}
     to   { opacity: 1; -moz-transform: scale(1);}
@@ -174,6 +172,7 @@
 .square {
   padding-bottom: 15px;
   padding-top: 15px;
+  animation: popin 0.5s; 
   -webkit-animation: popin 0.5s; 
   -moz-animation: popin 0.5s; 
 }


### PR DESCRIPTION
Response to issue https://github.com/ritstudentgovernment/petitions/issues/10 
As a quick fix, since the flashing seems to occur during DOM manipulation while all new squares are being added, giving the squares a pop-in animation as an entrance makes it less uncomfortable to the
eyes when scrolling down.
If the pop-in animation is too much, a regular fade-in css3 keyframe animation can easily be made as well to transition the newer squares into view. 
