### PR TITLE
Fixed #15, change timestamps slightly

### DIFF
--- a/client/helpers/handlebars.js
+++ b/client/helpers/handlebars.js
@@ -12,10 +12,19 @@ Handlebars.registerHelper('breaklines', function (text) {
 });
 
 Handlebars.registerHelper('formatDate', function (datetime, format) {
+  format = format || "l LT";
   if (moment) {
     return moment(datetime).format(format);
   }
   else {
+    return datetime;
+  }
+});
+
+Handlebars.registerHelper('relativeDate', function (datetime) {
+  if(moment) {
+    return moment(datetime).fromNow();
+  } else {
     return datetime;
   }
 });

--- a/client/helpers/handlebars.js
+++ b/client/helpers/handlebars.js
@@ -12,7 +12,6 @@ Handlebars.registerHelper('breaklines', function (text) {
 });
 
 Handlebars.registerHelper('formatDate', function (datetime, format) {
-  format = format || "l LT";
   if (moment) {
     return moment(datetime).format(format);
   }

--- a/client/stylesheets/petition.less
+++ b/client/stylesheets/petition.less
@@ -108,6 +108,14 @@
   margin: -0.25em auto auto -0.25em;
 }
 
+.petition-timestamp {
+  border-bottom: none!important;
+  float: left;
+  clear: left;
+  font-weight: normal;
+  text-transform: none;
+}
+
 .petition-title {
   font-size: 130%;
   line-height: 1.2;

--- a/client/stylesheets/petition.less
+++ b/client/stylesheets/petition.less
@@ -110,8 +110,6 @@
 
 .petition-timestamp {
   border-bottom: none!important;
-  float: left;
-  clear: left;
   font-weight: normal;
   text-transform: none;
 }

--- a/client/views/posts/post_card.html
+++ b/client/views/posts/post_card.html
@@ -9,6 +9,9 @@
       </h3>
       <p class="footer-subtitle">
         {{upcase post.author}}
+        <abbr class="petition-timestamp" title="{{formatDate post.created_at "l LT"}}" data-utime="{{ post.created_at }}">
+          {{relativeDate post.created_at }}
+        </abbr>
       </p>
     </div>
   </div>

--- a/client/views/posts/post_card.html
+++ b/client/views/posts/post_card.html
@@ -9,7 +9,8 @@
       </h3>
       <p class="footer-subtitle">
         {{upcase post.author}}
-        <abbr class="petition-timestamp" title="{{formatDate post.created_at "l LT"}}" data-utime="{{ post.created_at }}">
+        <br>
+        <abbr class="petition-timestamp" title="{{formatDate post.created_at "l LT"}}">
           {{relativeDate post.created_at }}
         </abbr>
       </p>

--- a/client/views/posts/post_page.html
+++ b/client/views/posts/post_page.html
@@ -5,7 +5,13 @@
         <div class="module module-sm">
           <p class="petition-title-wrapper">
             <p><a class="title" href="{{pathFor 'postPage' _id=post._id}}">{{post.title}}</a></p>
-            <div class="footer-subtitle">{{post.author}} <br> {{ submitted_at }}</div>
+            <div class="footer-subtitle">
+              {{post.author}}
+              <br>
+              <abbr class="petition-timestamp" title="{{formatDate post.created_at "l LT"}}">
+                {{relativeDate post.created_at }}
+              </abbr>
+            </div>
           </p>
           {{#if isInRole 'admin' 'moderator'}}
             <p>

--- a/client/views/posts/post_page.js
+++ b/client/views/posts/post_page.js
@@ -18,10 +18,6 @@ Template.postPage.helpers({
     timeTick.depend();
     return new moment(this.post.responded_at).fromNow().toUpperCase();
   },
-  'submitted_at': function () {
-    timeTick.depend();
-    return new moment(this.post.submitted).fromNow().toUpperCase();
-  },
   'initials': function () {
     return Meteor.users.find({
       '_id': {


### PR DESCRIPTION
This adds dates to petition cards, and changes very slightly how dates are shown on the single petition pages.

This adds a global handlebars relativeDate handler, for use with moment. This also changes the petition page to use that helper.

This implementation is similar to Facebook's relative date formats. It's nice because it displays the relative time which is enough in most cases, but the relative time's title is the actual date and time it was posted, for reference.

Please let me know if this could be improved.