### PR TITLE
Genericize ldap

### DIFF
--- a/server/ldap.js
+++ b/server/ldap.js
@@ -19,7 +19,7 @@ LDAP.checkAccount = function(options) {
   LDAP.client = ldap.createClient({
     url: Meteor.settings.LDAP.url,
     maxConnections: 2,
-    bindDN: 'cn=' + options.username + ',' + Meteor.settings.LDAP.search_ou,
+    bindDN: Meteor.settings.LDAP.bind_dn_prefix + options.username + ',' + Meteor.settings.LDAP.search_ou,
     bindCredentials: options.password
   });
   

--- a/server/ldap.js
+++ b/server/ldap.js
@@ -5,22 +5,24 @@ assert = Npm.require('assert');
 Future = Npm.require('fibers/future');
 
 LDAP = {};
-LDAP.searchOu = 'ou=People,dc=rit,dc=edu';
+LDAP.searchOu = Meteor.settings.LDAP.search_ou;
 LDAP.searchQuery = function(user){
   return {
-    filter: "(uid=" + user + ")",
+    filter: "(" + Meteor.settings.LDAP.username_attribute + "=" + user + ")",
     scope: 'sub'
   };
 };
 
 LDAP.checkAccount = function(options) {
   var dn, future;
+  //@TODO: Escape username and password per LDAP convention.
   LDAP.client = ldap.createClient({
-    url: Meteor.settings.LDAP_URL,
+    url: Meteor.settings.LDAP.url,
     maxConnections: 2,
-    bindDN:          'uid=' + options.username + ',ou=People,dc=rit,dc=edu',
+    bindDN: 'cn=' + options.username + ',' + Meteor.settings.LDAP.search_ou,
     bindCredentials: options.password
   });
+  
   options = options || {};
   dn = [];
   future = new Future();
@@ -28,18 +30,22 @@ LDAP.checkAccount = function(options) {
     future['return'](void 8);
     return;
   }
-  LDAP.client.search(LDAP.searchOu, LDAP.searchQuery(options.username), function(err, search) {
+  LDAP.client.search(LDAP.searchOu, LDAP.searchQuery(options.username), function(err, search) {    
     if (err) {
       future['return'](false);
       return false;
     } else {
       search.on('searchEntry', function(entry) {
         dn.push(entry.objectName);
+                        
         LDAP.displayName = entry.object.displayName;
         LDAP.givenName = entry.object.givenName;
         LDAP.initials = entry.object.initials;
         LDAP.sn = entry.object.sn;
         LDAP.ou = entry.object.ou;
+        LDAP.memberOf = entry.object.memberOf;
+        LDAP.mail = entry.object.mail;
+        
         return LDAP.displayName = entry.object.displayName;
       });
       search.on('error', function(err){
@@ -78,15 +84,20 @@ Accounts.registerLoginHandler('ldap', function(loginRequest) {
           givenName: LDAP.givenName || null,
           initials: LDAP.initials || null,
           sn: LDAP.sn || null,
-          name: name
+          name: name,
+          memberOf: LDAP.memberOf || null,
+          mail: LDAP.mail || null
         };
     if (user) {
       userId = user._id;
       profile.displayName = profile.displayName || user.profile.displayName || null;
-      profile.givenName = profile.givenName || user.profile.givenName || null;
-      profile.initials = profile.initials || user.profile.initials || null;
+      profile.givenName = profile.givenName || user.profile.givenName || null;      
       profile.sn = profile.sn || user.profile.sn || null;
-      profile.name = profile.name || user.profile.name || null;
+      profile.name = profile.name || user.profile.name || null;      
+      profile.email = profile.mail || user.profile.mail || null;
+      //When a user changes their initials or has it set for the first time, keep it.
+      profile.initials = user.profile.initials || profile.initials || null;
+      
       Meteor.users.update(userId, {$set: {profile: profile}});
     } else {
       userId = Meteor.users.insert({
@@ -98,6 +109,20 @@ Accounts.registerLoginHandler('ldap', function(loginRequest) {
         profile: profile
       });
     }
+       
+    if(Meteor.settings.LDAP.auto_group) {        
+        _.each(Meteor.settings.LDAP.auto_group, function(group, role) {
+            var autogroupAction = null;
+            if(profile.memberOf.indexOf(group) !== -1) {
+                autogroupAction = {$addToSet: {roles: role}};
+            }else{
+                autogroupAction = {$pull: {roles: role}};
+            }
+            
+            Meteor.users.update({_id: userId}, autogroupAction); 
+        });        
+    }
+            
     return {
       userId: userId
     };

--- a/settings.json.sample
+++ b/settings.json.sample
@@ -1,5 +1,16 @@
 {
-  "LDAP_URL": "ldaps://ldap.rit.edu",
+  "LDAP": {
+      "url": "ldaps://ldap.rit.edu/",
+      "search_ou": "ou=LDAP-Users,dc=rit,dc=edu",
+      //Change this to sAMAccountName if you are using Active Directory      
+      "username_attribute": "uid", 
+      //This is optional, it will place users in the admin or moderator role if they are
+      //in the specified groups.  This means memberOf is also available in the Meteor.user().profile
+      "auto_group": {
+          "admin": "CN=Admins,OU=Petitions,OU=Application-Specific-Access,DC=rit,DC=edu",
+          "moderator": "CN=Moderators,OU=Petitions,OU=Application-Specific-Access,DC=rit,DC=edu"
+      }           
+  },  
   "MAIL_URL": "smtp://username@main.ad.rit.edu:password@mymail.ad.rit.edu:587",
   "public" : {
     "ga": {

--- a/settings.json.sample
+++ b/settings.json.sample
@@ -4,8 +4,10 @@
       "search_ou": "ou=LDAP-Users,dc=rit,dc=edu",
       //Change this to sAMAccountName if you are using Active Directory      
       "username_attribute": "uid", 
+      //This is the prefix to your DN, change to something like cn= if you are using Active Directory.             
+      "bind_dn_prefix": "uid=",
       //This is optional, it will place users in the admin or moderator role if they are
-      //in the specified groups.  This means memberOf is also available in the Meteor.user().profile
+      //in the specified groups.  This means memberOf is also available in the Meteor.user().profile      
       "auto_group": {
           "admin": "CN=Admins,OU=Petitions,OU=Application-Specific-Access,DC=rit,DC=edu",
           "moderator": "CN=Moderators,OU=Petitions,OU=Application-Specific-Access,DC=rit,DC=edu"


### PR DESCRIPTION
This is an attempt to pull hard-coded RIT ldap settings from the application and place them in the settings file.  We use Active Directory, so I'm unable to test your environment.

Also, this code has an assumption that could cause it to not work with other institutions.  Every time you bind as a user it expects you to be under the ou=People,dc=rit,dc=edu path.  If an organization has several different OUs for users, like ou=Staff,dc=rit,dc=edu and ou=Faculty,dc=rit,dc=edu, then this login code won't work.  

I suggest another branch that does the following:

- Log in to LDAP with a service account
- Query for a user
- Get the DN for that user by supplied username
- Try to bind against that DN with the supplied password

This is a more resilient approach to logging in, but it doesn't really affect this branch since I'm just trying to remove hard-coded values from the app.