### PR TITLE
Edit initials

### DIFF
--- a/client/helpers/handlebars.js
+++ b/client/helpers/handlebars.js
@@ -84,3 +84,7 @@ var routeUtils = {
 Handlebars.registerHelper('isActiveRoute', function(route) {
   return routeUtils.testRoutes(route) ? 'active' : '';
 });
+
+Handlebars.registerHelper('publicSettings', function(route) {
+  return Meteor.settings.public;
+}); 

--- a/client/helpers/handlebars.js
+++ b/client/helpers/handlebars.js
@@ -87,4 +87,4 @@ Handlebars.registerHelper('isActiveRoute', function(route) {
 
 Handlebars.registerHelper('publicSettings', function(route) {
   return Meteor.settings.public;
-}); 
+});

--- a/client/views/users/user_edit.html
+++ b/client/views/users/user_edit.html
@@ -17,9 +17,27 @@
       <strong>About Me</strong>
     </div>
     <div class="panel-body">
-      <p><strong>Username:</strong> {{ user.username }}</p>
-      <p><strong>Name:</strong> {{ user.profile.name }}</p>
-      <strong>Initials:</strong> {{ user.profile.initials }}
+      <form id='profile-form'>
+        <p><strong>Username:</strong> {{ user.username }}</p>
+        <p><strong>Name:</strong> {{ user.profile.name }}</p>
+        <p>
+            <strong>Initials:</strong>
+            {{#if publicSettings.ui.initials_locked}}
+                {{ user.profile.initials }}
+            {{else}}
+                <input name="initials" value="{{ user.profile.initials }}" type="text" maxlength='5' />        
+            {{/if}}
+        </p>
+        <p><strong>Email:</strong> {{ user.profile.mail }}</p>
+        <p></p> 
+        {{#unless publicSettings.ui.initials_locked}}     
+            <div class="col-sm-12">
+            <input type="submit"
+                    class="btn btn-lg btn-primary no-margin full-width"
+                    value="Update Profile">
+            </div>
+        {{/unless}}
+      </form>
     </div>
   </div>
 </template>
@@ -30,7 +48,7 @@
       <strong>Notification Settings</strong>
     </div>
     <div class="panel-body">
-      <form>
+      <form id='notification-form'>
         <div class="checkbox">
           <label>
             <input name="notifyUpdates"

--- a/client/views/users/user_edit.js
+++ b/client/views/users/user_edit.js
@@ -1,5 +1,5 @@
 Template.userEdit.events({
-  'submit form': function(e) {
+  'submit #notification-form': function(e) {
     e.preventDefault();
 
     var notificationPrefs = {
@@ -13,6 +13,22 @@ Template.userEdit.events({
         throwError(error.reason);
       } else {
         throwError("Notification preferences saved.");
+      }
+    });
+  },
+  'submit #profile-form': function(e) {
+    e.preventDefault();
+
+    var profilePrefs = {
+      initials: $(e.target).find('[name=initials]').val()      
+    };
+    
+    Meteor.call('editProfile', profilePrefs, function(error) {
+      if (error) {
+        // display the error to the user
+        throwError(error.reason);
+      } else {
+        throwError("Profile saved.");
       }
     });
   },

--- a/collections/users.js
+++ b/collections/users.js
@@ -31,8 +31,15 @@ Meteor.methods({
     Meteor.users.update(user._id, {$set: {notify: notifyAttributes}});
   },
   editProfile: function(profilePrefs) {
+    var editingLocked;
+    try {
+        editingLocked = Meteor.settings.public.ui.initials_locked;
+    }catch(Exception){
+        editingLocked = false;
+    }
+    
     //Right now the only thing you can edit on your profile is your initials.
-    if(Meteor.settings.public.ui.initials_locked)
+    if(editingLocked)
       throw new Meteor.Error(403, "Initials are not editable.");
 
     var user = Meteor.user();

--- a/collections/users.js
+++ b/collections/users.js
@@ -29,5 +29,31 @@ Meteor.methods({
     }
     
     Meteor.users.update(user._id, {$set: {notify: notifyAttributes}});
+  },
+  editProfile: function(profilePrefs) {
+    //Right now the only thing you can edit on your profile is your initials.
+    if(Meteor.settings.public.ui.initials_locked)
+      throw new Meteor.Error(403, "Initials are not editable.");
+
+    var user = Meteor.user();
+
+    if (!user)
+      throw new Meteor.Error(401, "You need to login to update your profile.");
+
+    var initials = profilePrefs.initials;
+    
+    if (typeof initials != "string") {
+      throw new Meteor.Error(422, 'Profile preferences could not be saved.');
+    }
+    
+    if (initials.trim().length < 1) {
+      throw new Meteor.Error(422, 'Profile initials are too short.');
+    }
+    
+    if (initials.trim().length > 5) {
+      throw new Meteor.Error(422, 'Profile initials are too long.');
+    }
+    
+    Meteor.users.update(user._id, {$set: {'profile.initials': initials }});
   }
 });


### PR DESCRIPTION
This feature lets a user edit their initials unless locked through the settings file.  Example setting:

```
{
  ...  
  "public" : {
    "ui": {      
      "initials_locked": false
    },    
}
}
```

By default initials are editable unless disabled in the settings file.  Because this introduces a new helper, this pull request