### PR TITLE
Debounce setting petition Session vars when creating a new petition

### DIFF
--- a/client/views/petitions/petition_submit.js
+++ b/client/views/petitions/petition_submit.js
@@ -1,3 +1,11 @@
+//This function is called by event handlers and is debounced by a few milliseconds.  Since the Session is reactive,
+//if this is not debounced, a user could have their text overwritten by what was just put in the session a few milliseconds ago.
+var savePetitionSessionState = function() {
+  Session.set('petition.title', $('*[name=title]').val());
+  Session.set('petition.description', $('textarea[name=description]').val());
+  Session.set('petition.tag_ids', _.pluck($('#s2id_tags').select2('data'), '_id'));  
+};
+
 Template.petitionSubmit.helpers({
   'emptyPetition': function() {
 
@@ -45,7 +53,7 @@ Template.petitionSubmit.helpers({
       tag_ids: Session.get('petition.tag_ids')
     }
   },
-  'title': function() {
+  'title': function() {    
     return Session.get('petition.title');
   },
   'author': function() {
@@ -55,6 +63,9 @@ Template.petitionSubmit.helpers({
 
 Template.petitionSubmit.events({
   'submit form': function(e) {
+    //Since this function is debounced by event handlers, it may not have run yet.  This is to ensure someone doesn't
+    //quickly write up a petition and hammer the enter key before the debounced function is run.
+    savePetitionSessionState();
     e.preventDefault();
 
     var petition = {
@@ -70,6 +81,7 @@ Template.petitionSubmit.events({
         if (error.error === 302)
           Router.go('petitionPage', {_id: error.details})
       } else {
+        
         Session.set('petition.title', '');
         Session.set('petition.description', '');
         if(Singleton.findOne().moderation){
@@ -81,12 +93,8 @@ Template.petitionSubmit.events({
       }
     });
   },
-  'keyup *[name=title]': function (e) {
-    Session.set('petition.title', $('*[name=title]').val());
-  },
-  'keyup *[name=description]': function (e) {
-    Session.set('petition.description', $('textarea[name=description]').val());
-  }
+  'keyup *[name=title]': _.debounce(savePetitionSessionState, 250),
+  'keyup *[name=description]': _.debounce(savePetitionSessionState, 250)
 });
 
 Template.petitionSubmit.rendered = function () {
@@ -106,18 +114,7 @@ Template.petitionSubmit.rendered = function () {
     });
     $('.select2-search-field>input').addClass("input");
   });
-  $('#tags').on("change", function (e) {
-    var tag_ids = Session.get('petition.tag_ids')
-    if (e.added) {
-      tag_ids.push(e.added._id);
-      Session.set('petition.tag_ids', tag_ids);
-    } else if (e.removed) {
-      var tag_ids = _.without(tag_ids, e.removed._id);
-      Session.set('petition.tag_ids', tag_ids);
-    } else {
-      // to-do
-    }
-  });
+  $('#tags').on("change", savePetitionSessionState);
   // Accessing selected tags
   // $('#s2id_tags').select2('data');
 };


### PR DESCRIPTION
This is a fix for issue https://github.com/ritstudentgovernment/petitions/issues/60  Here is what I think was happening:

- User types in the title box
- petition.title key is updated in the session
- User types one more key
- Meteor reactive var code runs to update title textbox with petition.title session var
- User sees text they just entered disappear

This solves the problem by debouncing calls to Session.set until the user is done typing in the title or description field.  It also introduces just one method to save session state, which is fine because it's called much less frequently since it is debounced.