### PR TITLE
Added an optional import file to override brand colors.  Also cleaned…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .meteor/meteorite
 node_modules/*
 settings.json
+custom.branding.import.less

--- a/client/stylesheets/sites/petition.less
+++ b/client/stylesheets/sites/petition.less
@@ -1,5 +1,9 @@
 @import "_variables.import.less";
 
+.container h1 {
+  color: @brand-primary;
+}
+
 .filter-checkboxes {
     text-overflow: ellipsis;
     overflow:hidden;

--- a/client/stylesheets/vendor/custom.bootstrap.import.less
+++ b/client/stylesheets/vendor/custom.bootstrap.import.less
@@ -28,12 +28,11 @@
 @main-background: #eee;
 
 @brand-primary:         #F36E21;
-@brand-secondary: 		#513127;
+@brand-secondary:       #513127;
 @brand-success:         #513127;
 @brand-info:            #5bc0de;
 @brand-warning:         #f0ad4e;
 @brand-danger:          #d9534f;
-
 
 //== Scaffolding
 //
@@ -51,6 +50,8 @@
 //** Link hover decoration.
 @link-hover-decoration: underline;
 
+//Branding and overrides specific to the petition site, this file may not exist at runtime.
+@import (optional) "custom.branding.import.less";
 
 //== Typography
 //

--- a/client/views/petitions/petition_page.html
+++ b/client/views/petitions/petition_page.html
@@ -1,7 +1,7 @@
 <template name="petitionPage">
   <div class="container" style="background: white;width:100%!important;">
     <div class="container">
-            <h1 style="color:#f36e21;" class="long-string-fix text-center"><strong>{{petition.title}}</strong></h1>
+            <h1 class="long-string-fix text-center"><strong>{{petition.title}}</strong></h1>
             <p class="text-center">
               {{#each petition.tag_ids}}
                 {{#with tag this}}


### PR DESCRIPTION
This is a small change that is a huge quality of life improvement when branding the site.  I inserted an optional import for a file named "custom.branding.import.less" that should live at client/stylesheets/vendor/custom.branding.import.less

This file lets you override the branding set up in client/stylesheets/vendor/custom.bootstrap.import.less so I can keep a lot of your theming, but just tweak the colors on nearly all the site elements.

I also moved a hardcoded color from an element and put it in the petition.less file, so I can change it with my branding file.

If the custom branding file does not exist when the site is loaded, then it won't know to refresh the site when you add/edit it.  If you're testing this in development, make sure to restart the development server when testing whether it works with/without the import file.