### PR TITLE
Fixes typo: 'anyways' to 'anyway'

### DIFF
--- a/client/views/users/user_edit.html
+++ b/client/views/users/user_edit.html
@@ -91,7 +91,7 @@
           <p>Generating a new one will delete the old one.</p>
           <p><input type="submit"
                class="btn btn-danger get-key"
-               value="Make a new one anyways."></p>
+               value="Make a new one anyway."></p>
         </div>
       {{/if}}
 


### PR DESCRIPTION
Fixes the phrase "Make a new one anyways" referring to generating an API key in the profile view. Anyways isn't actually a real word.